### PR TITLE
PF-14388: Pilot migration golangci-lint-action

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Golangci lint
-        uses: golangci/golangci-lint-action@v3
+        uses: contentsquare/golangci-golangci-lint-action@approved-v3
         with:
           version: v1.51.0


### PR DESCRIPTION
PF-14388: Pilot migration golangci-lint-action

Migrates from `golangci/golangci-lint-action@v3` to `contentsquare/golangci-golangci-lint-action@approved-v3` for GitHub Actions security hardening.